### PR TITLE
Fixed fqdn and domain in attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,8 +16,8 @@
 # limitations under the License.
 
 default['postfix']['mail_type']  = "client"
-default['postfix']['myhostname'] = fqdn
-default['postfix']['mydomain']   = domain
+default['postfix']['myhostname'] = node['fqdn']
+default['postfix']['mydomain']   = node['domain']
 default['postfix']['myorigin']   = "$myhostname"
 default['postfix']['relayhost']  = ""
 default['postfix']['mail_relay_networks']        = "127.0.0.0/8"


### PR DESCRIPTION
Attributes were broken because 'fqdn' and 'domain' were not defined.
