### PR TITLE
COOK-1442 Adding conditional in case domain is missing (e.g. Vagrant).

### DIFF
--- a/templates/default/main.cf.erb
+++ b/templates/default/main.cf.erb
@@ -20,7 +20,9 @@ smtp_tls_CAfile = <%= node['postfix']['smtp_tls_cafile'] %>
 smtp_use_tls = <%= node['postfix']['smtp_use_tls'] %>
 <% end -%>
 myhostname = <%= node['postfix']['myhostname'] %>
+<% if node['postfix']['domain'] %>
 mydomain = <%= node['postfix']['mydomain'] %>
+<% end -%>
 myorigin = <%= node['postfix']['myorigin'] %>
 smtpd_banner = $myhostname ESMTP $mail_name 
 alias_maps = hash:/etc/aliases


### PR DESCRIPTION
Added a conditional around the 'mydomain' param in the main.cf.erb Template. 
- The prior behavior would insert an empty string for the 'mydomain' config param if `node['postfix']['domain']` is unset (such as in a Vagrant vm). This would throw an error on postfix startup.
- The new behavior inserts no 'mydomain' config param.

JIRA: http://tickets.opscode.com/browse/COOK-1442

PLEASEREVIEW: @jtimberman
