### PR TITLE
[COOK-1520] Add support for procmail as local delivery agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ See `attributes/default.rb` for default values.
 * `node['postfix']['aliases']` - hash of aliases to create with
   `recipe[postfix::aliases]`, see below under __Recipes__ for more
   information.
+* `node['postfix']['use_procmail']` - set to true if nodes should use
+  procmail as the delivery agent (mailbox_command).
+
 
 Recipes
 =======

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,4 +33,6 @@ default['postfix']['smtp_use_tls']    = "yes"
 default['postfix']['smtp_sasl_user_name'] = ""
 default['postfix']['smtp_sasl_passwd']    = ""
 
+default['postfix']['use_procmail'] = false
+
 default['postfix']['aliases'] = {}

--- a/metadata.rb
+++ b/metadata.rb
@@ -102,3 +102,8 @@ attribute "postfix/multi_environment_relay",
   :display_name => "Postfix Search for relayhost in any environment",
   :description => "If true, then the client recipe will search any environment instead of just the node's",
   :default => ""
+  
+attribute "postfix/use_procmail",
+  :display_name => "Postfix Use procmail?",
+  :description => "Whether procmail should be used as the local delivery agent for a server",
+  :default => "no"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,6 +22,13 @@ package "postfix" do
   action :install
 end
 
+if node['postfix']['use_procmail'] then
+  package "procmail" do 
+    action :install
+  end
+end
+
+
 service "postfix" do
   supports :status => true, :restart => true, :reload => true
   action :enable

--- a/templates/default/main.cf.erb
+++ b/templates/default/main.cf.erb
@@ -37,5 +37,8 @@ relayhost = <%= node['postfix']['relayhost'] %>
 mynetworks = <%= node['postfix']['mail_relay_networks'] %>
 inet_interfaces = loopback-only
 <% end -%>
+<% if node['postfix']['use_procmail'] -%>
+mailbox_command = /usr/bin/procmail -a "$EXTENSION"
+<% end -%>
 mailbox_size_limit = 0
 recipient_delimiter = +


### PR DESCRIPTION
Added simple support to use procmail locally on a postfix server via new attribute.  Tested on Ubuntu 10.04 and CentOS/RHEL 5.
