### PR TITLE
Updated directory for cache to avoid warning in Postfix > 2.5

### DIFF
--- a/templates/default/main.cf.erb
+++ b/templates/default/main.cf.erb
@@ -9,9 +9,9 @@ smtpd_use_tls = <%= node['postfix']['smtpd_use_tls'] %>
 <% if node['postfix']['smtpd_use_tls'] == "yes" -%>
 smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
 smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
-smtpd_tls_session_cache_database = btree:${queue_directory}/smtpd_scache
+smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 <% end -%>
-smtp_tls_session_cache_database = btree:${queue_directory}/smtp_scache
+smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 smtp_sasl_auth_enable = <%= node['postfix']['smtp_sasl_auth_enable'] %>
 <% if node['postfix']['smtp_sasl_auth_enable'] == "yes" -%>
 smtp_sasl_password_maps = <%= node['postfix']['smtp_sasl_password_maps'] %>


### PR DESCRIPTION
See here: http://www.postfix.org/TLS_README.html#server_tls_cache
