### PR TITLE
[COOK-2281] postfix aliases uses require_recipe statement yet, should be include_recipe.

### DIFF
--- a/recipes/aliases.rb
+++ b/recipes/aliases.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require_recipe "postfix"
+include_recipe "postfix"
 
 execute "update-postfix-aliases" do
   command "newaliases"


### PR DESCRIPTION
Pull request for [COOK-2281](http://tickets.opscode.com/browse/COOK-2281)

This commit passes two tests, following

・kitchen test
・foodcritic
