### PR TITLE
Support setting SELinux security contexts on modified files

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,3 +49,10 @@ default['postfix']['canonical_classes'] = nil
 default['postfix']['sender_canonical_maps'] = nil
 default['postfix']['recipient_canonical_maps'] = nil
 default['postfix']['canonical_maps'] = nil
+
+case platform
+when "centos","redhat","fedora"
+  default['postfix']['selinux'] = true
+else
+  default['postfix']['selinux'] = false
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -58,6 +58,18 @@ end
     notifies :restart, "service[postfix]"
 
   end
+
+  script "restorecon-#{cfg}" do
+    interpreter "bash"
+    code "restorecon /etc/postfix/#{cfg}.cf"
+    only_if {node['postfix']['selinux']}
+  end
+end
+
+script "chcon-sender_canonical" do
+  interpreter "bash"
+  code "chcon -t postfix_etc_t /etc/postfix/sender_canonical"
+  only_if {node['postfix']['selinux']}
 end
 
 service "postfix" do


### PR DESCRIPTION
On RedHat and related platforms, the Postfix package comes SELinux-enabled. The changes that this cookbook makes to Postfix config files cause them to lose their security context (postfix_etc_t) making them unreadable by the Postfix daemon.

This patch adds a boolean attribute (selinux) which, if set, causes the cookbook to attempt to set the security context for modified files. The attribute is true by default on RedHat, CentOS, and Fedora.

http://tickets.opscode.com/browse/COOK-2418
