### PR TITLE
Add configuraration option append_dot_mydomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ See `attributes/default.rb` for default values.
   'loopback-only' for non-master (anything else) `mail_type`.
 * `node['postfix']['mail_relay_networks']` - corresponds to the
   mynetworks option in `/etc/postfix/main.cf`.
+* `node['postfix']['append_dot_mydomain']` - corresponds to the
+  append_dot_mydomain option in `/etc/postfix/main.cf`.
 * `node['postfix']['smtpd_use_tls']` - set to "yes" to use TLS for
   SMTPD, which will use the snakeoil certs.
 * `node['postfix']['smtp_sasl_auth_enable']` - set to "yes" to enable

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,6 +21,7 @@ default['postfix']['mydomain']   = node['domain']
 default['postfix']['myorigin']   = "$myhostname"
 default['postfix']['relayhost']  = ""
 default['postfix']['mail_relay_networks']        = "127.0.0.0/8"
+default['postfix']['append_dot_mydomain']        = "yes"
 default['postfix']['relayhost_role']             = "relayhost"
 default['postfix']['multi_environment_relay'] = false
 default['postfix']['inet_interfaces'] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -54,6 +54,11 @@ attribute "postfix/mail_relay_networks",
   :description => "Sets the mynetworks value in main.cf",
   :default => "127.0.0.0/8"
 
+attribute "postfix/append_dot_mydomain",
+  :display_name => "Postfix Append My Domain",
+  :description => "Sets the append_dot_mydomain value in main.cf",
+  :default => "yes"
+
 attribute "postfix/smtp_sasl_auth_enable",
   :display_name => "Postfix SMTP SASL Auth Enable",
   :description => "Enable SMTP SASL Authentication",
@@ -108,7 +113,7 @@ attribute "postfix/multi_environment_relay",
   :display_name => "Postfix Search for relayhost in any environment",
   :description => "If true, then the client recipe will search any environment instead of just the node's",
   :default => ""
-  
+
 attribute "postfix/use_procmail",
   :display_name => "Postfix Use procmail?",
   :description => "Whether procmail should be used as the local delivery agent for a server",

--- a/templates/default/main.cf.erb
+++ b/templates/default/main.cf.erb
@@ -4,7 +4,7 @@
 ###
 
 biff = no
-append_dot_mydomain = no
+append_dot_mydomain = <%= node['postfix']['append_dot_mydomain'] %>
 smtpd_use_tls = <%= node['postfix']['smtpd_use_tls'] %>
 <% if node['postfix']['smtpd_use_tls'] == "yes" -%>
 smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem


### PR DESCRIPTION
(from postfix manual..)
append_dot_mydomain (default: yes)

With locally submitted mail, append the string ".$mydomain" to addresses
that have no ".domain" information. With remotely submitted mail, append
the string ".$remote_header_rewrite_domain" instead.

Note 1: this feature is enabled by default. If disabled, users will not
be able to send mail to "user@partialdomainname" but will have to
specify full domain names instead.

Note 2: with Postfix version 2.2, message header address rewriting
happens only when one of the following conditions is true:
- The message is received with the Postfix sendmail(1) command,
- The message is received from a network client that matches $local_header_rewrite_clients,
- The message is received from the network, and the remote_header_rewrite_domain parameter specifies a non-empty value.
