### PR TITLE
Replace fallback_relay with smtp_fallback_relay in master.cf

### DIFF
--- a/templates/default/master.cf.erb
+++ b/templates/default/master.cf.erb
@@ -31,7 +31,7 @@ proxymap  unix  -       -       n       -       -       proxymap
 smtp      unix  -       -       n       -       500     smtp
 # When relaying mail as backup MX, disable fallback_relay to avoid MX loops
 relay     unix  -       -       n       -       -       smtp
-	-o fallback_relay=
+	-o smtp_fallback_relay=
 #       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5
 showq     unix  n       -       n       -       -       showq
 error     unix  -       -       n       -       -       error


### PR DESCRIPTION
fallback_relay was renamed to smtp_fallback_relay in Postfix 2.3
