### PR TITLE
Add attribute for setting main.cf variable 'header_size_limit'

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,3 +49,5 @@ default['postfix']['canonical_classes'] = nil
 default['postfix']['sender_canonical_maps'] = nil
 default['postfix']['recipient_canonical_maps'] = nil
 default['postfix']['canonical_maps'] = nil
+
+default['postfix']['header_size_limit'] = nil

--- a/templates/default/main.cf.erb
+++ b/templates/default/main.cf.erb
@@ -40,6 +40,9 @@ inet_interfaces = <%= node['postfix']['inet_interfaces'] || 'loopback-only' %>
 <% if node['postfix']['use_procmail'] -%>
 mailbox_command = /usr/bin/procmail -a "$EXTENSION"
 <% end -%>
+<% if node['postfix']['header_size_limit'] -%>
+header_size_limit = <%= node['postfix']['header_size_limit'] %>
+<% end -%>
 mailbox_size_limit = 0
 recipient_delimiter = +
 


### PR DESCRIPTION
I'm using Postfix to relay mail to SendGrid.  In SendGrid docs for this they specify configuring main.cf with:

```
header_size_limit = 4096000
```

http://sendgrid.com/docs/Integrate/Mail_Servers/postfix.html

Nice to be able to do it from my Postfix Chef cookbook so I added the attribute and corresponding lines in the main.cf template.  Probably some other folks out there integrating with SendGrid who would like this too.
