### PR TITLE
Use node['fqdn'] instead of node['hostname'] for mydestination.

### DIFF
--- a/templates/default/main.cf.erb
+++ b/templates/default/main.cf.erb
@@ -27,7 +27,7 @@ myorigin = <%= node['postfix']['myorigin'] %>
 smtpd_banner = $myhostname ESMTP $mail_name
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
-mydestination = <%= node['postfix']['myhostname'] %>, <%= node['hostname'] %>, localhost.localdomain, localhost
+mydestination = <%= node['postfix']['myhostname'] %>, <%= node['fqdn'] %>, localhost.localdomain, localhost
 <% if node['postfix']['mail_type'] == "master" -%>
 relayhost =
 mynetworks = <%= node['postfix']['mail_relay_networks'] %>


### PR DESCRIPTION
Because node['postfix']['myhostname'] is most likely the same with  node['hostname'] because it's supposed to be used with node['postfix']['mydomain'], I think it makes more sense to have node['fqdn'] than node['hostname'] again in the list.
