### PR TITLE
[COOK-3586]

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -37,6 +37,6 @@ else
   relayhost = results.map {|n| n['ipaddress']}.first
 end
 
-node.set['postfix']['relayhost'] = "[#{relayhost}]"
+node.set['postfix']['main']['relayhost'] = "[#{relayhost}]"
 
 include_recipe "postfix"


### PR DESCRIPTION
Fixed the relayhost attribute in the client recipe, should be
namespaced as postfix.main.relayhost
