### PR TITLE
[COOK-3617] Fix no method chomp on NilClass attribute errors

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,8 +36,8 @@ end
 # Non-default main.cf attributes
 default['postfix']['main']['biff'] = "no"
 default['postfix']['main']['append_dot_mydomain'] = "no"
-default['postfix']['main']['myhostname'] = node['fqdn'].chomp('.') || node['hostname'].chomp('.')
-default['postfix']['main']['mydomain'] = node['domain'].chomp('.') || node['hostname'].chomp('.')
+default['postfix']['main']['myhostname'] = (node['fqdn'] || node['hostname']).to_s.chomp('.')
+default['postfix']['main']['mydomain'] = (node['domain'] || node['hostname']).to_s.chomp('.')
 default['postfix']['main']['myorigin'] = "$myhostname"
 default['postfix']['main']['mydestination'] = [ node['postfix']['main']['myhostname'], node['hostname'], "localhost.localdomain", "localhost" ].compact
 default['postfix']['main']['smtpd_use_tls'] = "yes"


### PR DESCRIPTION
The hostname/myhost/mydomain attributes try to chomp on a nil value,
mainly the node["domain"] attribute. Additionally, || is used after a
chomp, so empty string values will probably never hit the second half of
the statement.

Code like this makes me with we had active_support/blank in core Ruby.

Fixes https://tickets.opscode.com/browse/COOK-3617
