### PR TITLE
[COOK-2551] Support creating the sender_canonical map file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,7 @@ default['postfix']['use_procmail'] = false
 default['postfix']['aliases'] = {}
 default['postfix']['main_template_source'] = "postfix"
 default['postfix']['master_template_source'] = "postfix"
+default['postfix']['sender_canonical_map_entries'] = {}
 
 case node['platform']
 when 'smartos'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -43,6 +43,19 @@ when "rhel", "fedora"
   end
 end
 
+if not node['postfix']['sender_canonical_map_entries'].empty?
+  template "#{node['postfix']['conf_dir']}/sender_canonical" do
+    owner "root"
+    group 0
+    mode 00644
+    notifies :restart, "service[postfix]"
+  end
+
+  if not node['postfix']['main'].has_key?('sender_canonical_maps')
+    node['postfix']['main']['sender_canonical_maps'] = "hash:#{node['postfix']['conf_dir']}/sender_canonical"
+  end
+end
+
 %w{main master}.each do |cfg|
   template "#{node['postfix']['conf_dir']}/#{cfg}.cf" do
     source "#{cfg}.cf.erb"


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-2551

The cookbook supports telling Postfix where to find a sender_canonical map file, but not actually creating one. This patch adds a new attribute, sender_canonical_map, which if populated gets used to create a file in the location specified by sender_canonical_maps.

This is a duplicate of a previous request attempting to address comments in the Jira ticket.
