### PR TITLE
fix sasl_relayhost example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,12 @@ override_attributes(
     "mail_type" => "master",
     "main" => {
       "mynetworks" => "10.3.3.0/24",
-      "mail_type" => "master",
       "mydomain" => "example.com",
       "myorigin" => "example.com",
       "relayhost" => "[smtp.comcast.net]:587",
-      "smtp_sasl_auth_enable" => "yes",
+      "smtp_sasl_auth_enable" => "yes"
+    },
+    "sasl" => {
       "smtp_sasl_passwd" => "your_password",
       "smtp_sasl_user_name" => "your_username"
     }


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3822

An update to the readme.md - the example here isn't correct.
