### PR TITLE
[COOK-3824] Fix list construction in main.cf.erb

### DIFF
--- a/templates/default/main.cf.erb
+++ b/templates/default/main.cf.erb
@@ -5,14 +5,7 @@
 
 <% @settings.sort.map do |key, value| -%>
 <%  if value.kind_of? Array -%>
-<%=   "#{key} = " -%>
-<%    value.each do |item| -%>
-<%      if value.last == item -%>
-<%=       item %>
-<%      else -%>
-<%=       "#{item}, " -%>
-<%      end -%>
-<%    end -%>
+<%=   "#{key} = #{value.join(', ')}"%>
 <%  else -%>
 <%=   "#{key} = #{value}"%>
 <%  end -%>


### PR DESCRIPTION
The previous code would take any array item that is equal to the last
one as the last one and print a line break.  Fix that using join, which
is also much simpler.

Signed-off-by: Peter Eisentraut peisentraut@meetme.com
