### PR TITLE
[COOK-4410] Fix sender_canonical configuration by adding template and postmap execution

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -48,8 +48,8 @@ if !node['postfix']['sender_canonical_map_entries'].empty?
     owner 'root'
     group 0
     mode  '0644'
-    notifies :restart, 'service[postfix]'
     notifies :run, 'execute[update-postfix-sender_canonical]'
+    notifies :reload, 'service[postfix]'
   end
 
   if !node['postfix']['main'].key?('sender_canonical_maps')

--- a/templates/default/sender_canonical.erb
+++ b/templates/default/sender_canonical.erb
@@ -6,5 +6,5 @@
 # See man 5 canonical for format
 
 <% node['postfix']['sender_canonical_map_entries'].each do |name, value| %>
-<%= name %> <%= [value].flatten.map{|x| %Q(#{x})}.join(', ') %>
+<%= name %> <%= value %>
 <% end unless node['postfix']['sender_canonical_map_entries'].nil? %>


### PR DESCRIPTION
Created sender_canonical.erb template and also added command to execute postmap on the sender_canonical file when changed.

This will fix the addition from PR #48
