### PR TITLE
moving conditional attributes to a recipe

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -79,61 +79,16 @@ default['postfix']['main']['mailbox_size_limit'] = 0
 default['postfix']['main']['mynetworks'] = nil
 default['postfix']['main']['inet_interfaces'] = 'loopback-only'
 
-# Conditional attributes
+# Conditional attributes, also reference _attributes recipe
 case node['platform_family']
 when 'smartos'
   default['postfix']['main']['smtpd_use_tls'] = 'no'
   default['postfix']['main']['smtp_use_tls'] = 'no'
-  cafile = '/opt/local/etc/postfix/cacert.pem'
+  default['postfix']['cafile'] = '/opt/local/etc/postfix/cacert.pem'
 when 'rhel'
-  cafile = '/etc/pki/tls/cert.pem'
+  default['postfix']['cafile'] = '/etc/pki/tls/cert.pem'
 else
-  cafile = "#{node['postfix']['conf_dir']}/cacert.pem"
-end
-
-if node['postfix']['use_procmail']
-  default['postfix']['main']['mailbox_command'] = '/usr/bin/procmail -a "$EXTENSION"'
-end
-
-if node['postfix']['main']['smtpd_use_tls'] == 'yes'
-  default['postfix']['main']['smtpd_tls_cert_file'] = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
-  default['postfix']['main']['smtpd_tls_key_file'] = '/etc/ssl/private/ssl-cert-snakeoil.key'
-  default['postfix']['main']['smtpd_tls_CAfile'] = cafile
-  default['postfix']['main']['smtpd_tls_session_cache_database'] = 'btree:${data_directory}/smtpd_scache'
-end
-
-if node['postfix']['main']['smtp_use_tls'] == 'yes'
-  default['postfix']['main']['smtp_tls_CAfile'] = cafile
-  default['postfix']['main']['smtp_tls_session_cache_database'] = 'btree:${data_directory}/smtp_scache'
-end
-
-if node['postfix']['main']['smtp_sasl_auth_enable'] == 'yes'
-  default['postfix']['sasl_password_file'] = "#{node['postfix']['conf_dir']}/sasl_passwd"
-  default['postfix']['main']['smtp_sasl_password_maps'] = "hash:#{node['postfix']['sasl_password_file']}"
-  default['postfix']['main']['smtp_sasl_security_options'] = 'noanonymous'
-  default['postfix']['sasl']['smtp_sasl_user_name'] = ''
-  default['postfix']['sasl']['smtp_sasl_passwd']    = ''
-  default['postfix']['main']['relayhost'] = ''
-end
-
-if node['postfix']['use_alias_maps']
-   default['postfix']['main']['alias_maps'] = ["hash:#{node['postfix']['aliases_db']}"]
-end
-
-if node['postfix']['use_transport_maps']
-   default['postfix']['main']['transport_maps'] = ["hash:#{node['postfix']['transport_db']}"]
-end
-
-if node['postfix']['use_access_maps']
-   default['postfix']['main']['access_maps'] = ["hash:#{node['postfix']['access_db']}"]
-end
-
-if node['postfix']['use_virtual_aliases']
-  default['postfix']['main']['virtual_alias_maps'] = ["#{node['postfix']['virtual_alias_db_type']}:#{node['postfix']['virtual_alias_db']}"]
-end
-
-if node['postfix']['use_virtual_aliases_domains']
-  default['postfix']['main']['virtual_alias_domains'] = ["#{node['postfix']['virtual_alias_domains_db_type']}:#{node['postfix']['virtual_alias_domains_db']}"]
+  default['postfix']['cafile'] = "#{node['postfix']['conf_dir']}/cacert.pem"
 end
 
 # # Default main.cf attributes according to `postconf -d`

--- a/recipes/_attributes.rb
+++ b/recipes/_attributes.rb
@@ -1,0 +1,60 @@
+# encoding: utf-8
+# Copyright:: Copyright 2012-2014, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if node['postfix']['use_procmail']
+  node.default['postfix']['main']['mailbox_command'] = '/usr/bin/procmail -a "$EXTENSION"'
+end
+
+if node['postfix']['main']['smtpd_use_tls'] == 'yes'
+  node.default['postfix']['main']['smtpd_tls_cert_file'] = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
+  node.default['postfix']['main']['smtpd_tls_key_file'] = '/etc/ssl/private/ssl-cert-snakeoil.key'
+  node.default['postfix']['main']['smtpd_tls_CAfile'] = node['postfix']['cafile']
+  node.default['postfix']['main']['smtpd_tls_session_cache_database'] = 'btree:${data_directory}/smtpd_scache'
+end
+
+if node['postfix']['main']['smtp_use_tls'] == 'yes'
+  node.default['postfix']['main']['smtp_tls_CAfile'] = node['postfix']['cafile']
+  node.default['postfix']['main']['smtp_tls_session_cache_database'] = 'btree:${data_directory}/smtp_scache'
+end
+
+if node['postfix']['main']['smtp_sasl_auth_enable'] == 'yes'
+  node.default['postfix']['sasl_password_file'] = "#{node['postfix']['conf_dir']}/sasl_passwd"
+  node.default['postfix']['main']['smtp_sasl_password_maps'] = "hash:#{node['postfix']['sasl_password_file']}"
+  node.default['postfix']['main']['smtp_sasl_security_options'] = 'noanonymous'
+  node.default['postfix']['sasl']['smtp_sasl_user_name'] = ''
+  node.default['postfix']['sasl']['smtp_sasl_passwd']    = ''
+  node.default['postfix']['main']['relayhost'] = ''
+end
+
+if node['postfix']['use_alias_maps']
+   node.default['postfix']['main']['alias_maps'] = ["hash:#{node['postfix']['aliases_db']}"]
+end
+
+if node['postfix']['use_transport_maps']
+   node.default['postfix']['main']['transport_maps'] = ["hash:#{node['postfix']['transport_db']}"]
+end
+
+if node['postfix']['use_access_maps']
+   node.default['postfix']['main']['access_maps'] = ["hash:#{node['postfix']['access_db']}"]
+end
+
+if node['postfix']['use_virtual_aliases']
+  node.default['postfix']['main']['virtual_alias_maps'] = ["#{node['postfix']['virtual_alias_db_type']}:#{node['postfix']['virtual_alias_db']}"]
+end
+
+if node['postfix']['use_virtual_aliases_domains']
+  node.default['postfix']['main']['virtual_alias_domains'] = ["#{node['postfix']['virtual_alias_domains_db_type']}:#{node['postfix']['virtual_alias_domains_db']}"]
+end

--- a/recipes/_common.rb
+++ b/recipes/_common.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+include_recipe 'postfix::_attributes'
+
 package 'postfix'
 
 package 'procmail' if node['postfix']['use_procmail']


### PR DESCRIPTION
Some users, such as myself, only set attributes in an attributes file and/or recipe. We do not use roles or environments to set attributes. If conditions in an attributes file are determined before a recipe is compiled and before other attribute recipes are considered.

At this point it is impossible to set default['postfix']['virtual_alias_domains'] without using the role or environment for an override. This change is set to resolve this issue and allows the ability to override attributes through other attributes file and/or recipes.
