### PR TITLE
replace directive "smtp_use_tls" w/ "smtp_tls_security_level" (2.3+ compat) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ This change in namespace to `node['postfix']['main']` should allow for greater f
 * `node['postfix']['main']['alias_maps']` - set to `hash:/etc/aliases`
 * `node['postfix']['main']['mailbox_size_limit']` - set to `0` (disabled)
 * `node['postfix']['main']['mydestination']` - default fqdn, hostname, localhost.localdomain, localhost
-* `node['postfix']['main']['smtpd_use_tls']` - (yes/no); default yes. See conditional cert/key attributes.
+* `node['postfix']['main']['smtpd_tls_security_level']` - (none/may/encrypt); default may. See conditional cert/key attributes.
   - `node['postfix']['main']['smtpd_tls_cert_file']` - conditional attribute, set to full path of server's x509 certificate.
   - `node['postfix']['main']['smtpd_tls_key_file']` - conditional attribute, set to full path of server's private key
   - `node['postfix']['main']['smtpd_tls_CAfile']` - set to platform specific CA bundle
   - `node['postfix']['main']['smtpd_tls_session_cache_database']` - set to `btree:${data_directory}/smtpd_scache`
-* `node['postfix']['main']['smtp_use_tls']` - (yes/no); default yes.  See following conditional attributes.
+* `node['postfix']['main']['smtp_tls_security_level']` - (may/encrypt/dane/dane-only/fingerprint/verify/secure/none); default may.  See following conditional attributes.
   - `node['postfix']['main']['smtp_tls_CAfile']` - set to platform specific CA bundle
   - `node['postfix']['main']['smtp_tls_session_cache_database']` - set to `btree:${data_directory}/smtpd_scache`
 * `node['postfix']['main']['smtp_sasl_auth_enable']` - (yes/no); default no.  If enabled, see following conditional attributes.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -72,18 +72,26 @@ default['postfix']['main']['myhostname'] = (node['fqdn'] || node['hostname']).to
 default['postfix']['main']['mydomain'] = (node['domain'] || node['hostname']).to_s.chomp('.')
 default['postfix']['main']['myorigin'] = '$myhostname'
 default['postfix']['main']['mydestination'] = [node['postfix']['main']['myhostname'], node['hostname'], 'localhost.localdomain', 'localhost'].compact
-default['postfix']['main']['smtpd_use_tls'] = 'yes'
-default['postfix']['main']['smtp_use_tls'] = 'yes'
+default['postfix']['main']['smtpd_tls_security_level'] = 'may'
+default['postfix']['main']['smtp_tls_security_level'] = 'may'
 default['postfix']['main']['smtp_sasl_auth_enable'] = 'no'
 default['postfix']['main']['mailbox_size_limit'] = 0
 default['postfix']['main']['mynetworks'] = nil
 default['postfix']['main']['inet_interfaces'] = 'loopback-only'
+# With Postfix 2.3 and later use smtpd_tls_security_level instead.
+# default['postfix']['main']['smtpd_use_tls'] = 'no'
+# With Postfix 2.3 and later use smtp_tls_security_level instead.
+# default['postfix']['main']['smtp_use_tls'] = 'no'
+
 
 # Conditional attributes, also reference _attributes recipe
 case node['platform_family']
 when 'smartos'
-  default['postfix']['main']['smtpd_use_tls'] = 'no'
-  default['postfix']['main']['smtp_use_tls'] = 'no'
+  default['postfix']['main']['smtpd_tls_security_level'] = 'may'
+  default['postfix']['main']['smtp_tls_security_level'] = 'may'
+  # With Postfix 2.3 and later use smtpd_tls_security_level instead.
+  # default['postfix']['main']['smtpd_use_tls'] = 'no'
+  # default['postfix']['main']['smtp_use_tls'] = 'no'
   default['postfix']['cafile'] = '/opt/local/etc/postfix/cacert.pem'
 when 'rhel'
   default['postfix']['cafile'] = '/etc/pki/tls/cert.pem'

--- a/recipes/_attributes.rb
+++ b/recipes/_attributes.rb
@@ -18,14 +18,15 @@ if node['postfix']['use_procmail']
   node.default['postfix']['main']['mailbox_command'] = '/usr/bin/procmail -a "$EXTENSION"'
 end
 
-if node['postfix']['main']['smtpd_use_tls'] == 'yes'
+if node['postfix']['main']['smtpd_use_tls'] == 'yes' or ['may', 'encrypt'].include? node['postfix']['main']['smtpd_tls_security_level']
   node.default['postfix']['main']['smtpd_tls_cert_file'] = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
   node.default['postfix']['main']['smtpd_tls_key_file'] = '/etc/ssl/private/ssl-cert-snakeoil.key'
   node.default['postfix']['main']['smtpd_tls_CAfile'] = node['postfix']['cafile']
   node.default['postfix']['main']['smtpd_tls_session_cache_database'] = 'btree:${data_directory}/smtpd_scache'
 end
 
-if node['postfix']['main']['smtp_use_tls'] == 'yes'
+smtp_tls_security_level_options = ['may', 'encrypt', 'dane', 'dane-only', 'fingerprint', 'verify', 'secure']
+if node['postfix']['main']['smtp_use_tls'] == 'yes' or smtp_tls_security_level_options.include? node['postfix']['main']['smtp_tls_security_level']
   node.default['postfix']['main']['smtp_tls_CAfile'] = node['postfix']['cafile']
   node.default['postfix']['main']['smtp_tls_session_cache_database'] = 'btree:${data_directory}/smtp_scache'
 end


### PR DESCRIPTION
Use of the smtp_use_tls directive is still supported, but by default the smtpd_tls_security_level is set.

http://www.postfix.org/postconf.5.html#smtpd_tls_security_level

"This feature is available in Postfix 2.3 and later."
