### PR TITLE
Added restrictions to main.cf template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This change in namespace to `node['postfix']['main']` should allow for greater f
 * `node['postfix']['main']['smtp_use_tls']` - (yes/no); default yes.  See following conditional attributes.
   - `node['postfix']['main']['smtp_tls_CAfile']` - set to platform specific CA bundle
   - `node['postfix']['main']['smtp_tls_session_cache_database']` - set to `btree:${data_directory}/smtpd_scache`
+* `node['postfix']['main']['restrictions']` - default is nil, could be a hash with restrictions.
 * `node['postfix']['main']['smtp_sasl_auth_enable']` - (yes/no); default no.  If enabled, see following conditional attributes.
   - `node['postfix']['main']['smtp_sasl_password_maps']` - Set to `hash:/etc/postfix/sasl_passwd` template file
   - `node['postfix']['main']['smtp_sasl_security_options']` - Set to noanonymous
@@ -283,6 +284,26 @@ override_attributes(
       "chef.io" => "OK",
       ".chef.io" => "OK",
       "example.com" => "OK"
+    }
+  }
+)
+```
+
+The example roles below sets up some restrictions on helo:
+
+```ruby
+name "base"
+run_list("recipe[postfix]")
+override_attributes(
+  "postfix" => {
+    "main" => {
+      "restrictions" => {
+        "helo" => [
+          "permit_mynetworks",
+          "reject_non_fqdn_helo_hostname",
+          "reject_invalid_helo_hostname"
+        ]
+      }
     }
   }
 )

--- a/templates/default/aliases.erb
+++ b/templates/default/aliases.erb
@@ -7,5 +7,5 @@
 postmaster:    root
 
 <% node['postfix']['aliases'].each do |name, value| %>
-<%= name %>: <%= [value].flatten.map{|x| %Q("#{x}")}.join(', ') %>
+<%= name %>: <%= [value].flatten.map{|x| %Q(#{x})}.join(', ') %>
 <% end unless node['postfix']['aliases'].nil? %>

--- a/templates/default/main.cf.erb
+++ b/templates/default/main.cf.erb
@@ -4,10 +4,17 @@
 ###
 
 <% @settings.sort.map do |key, value| -%>
-<%  next if value.nil? -%>
+<%  next if (value.nil? || key == 'restrictions') -%>
 <%  if value.kind_of? Array -%>
 <%=   "#{key} = #{value.join(', ')}"%>
 <%  else -%>
 <%=   "#{key} = #{value}"%>
 <%  end -%>
 <% end -%>
+
+<% @settings['restrictions'].each do |name, type| %>
+smtpd_<%= name %>_restrictions =
+<% type.each do |value| %>
+  <%= value %>
+<% end %>
+<% end unless @settings['restrictions'].nil? %>


### PR DESCRIPTION
Postfix supports restrictions for helo, sender, data, recipient, etc. Those restrictions can be added using simple arrays with the simple changes introduced here.
