### PR TITLE
Using node.default_unless instead of node.default in _attributes

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -6,4 +6,5 @@ group :integration do
   cookbook 'apt'
   cookbook 'yum'
   cookbook 'fake', :path => 'test/fixtures/cookbooks/fake'
+  cookbook 'wrapper', :path => 'test/fixtures/cookbooks/wrapper'
 end

--- a/recipes/_attributes.rb
+++ b/recipes/_attributes.rb
@@ -15,46 +15,46 @@
 #
 
 if node['postfix']['use_procmail']
-  node.default['postfix']['main']['mailbox_command'] = '/usr/bin/procmail -a "$EXTENSION"'
+  node.default_unless['postfix']['main']['mailbox_command'] = '/usr/bin/procmail -a "$EXTENSION"'
 end
 
 if node['postfix']['main']['smtpd_use_tls'] == 'yes'
-  node.default['postfix']['main']['smtpd_tls_cert_file'] = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
-  node.default['postfix']['main']['smtpd_tls_key_file'] = '/etc/ssl/private/ssl-cert-snakeoil.key'
-  node.default['postfix']['main']['smtpd_tls_CAfile'] = node['postfix']['cafile']
-  node.default['postfix']['main']['smtpd_tls_session_cache_database'] = 'btree:${data_directory}/smtpd_scache'
+  node.default_unless['postfix']['main']['smtpd_tls_cert_file'] = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
+  node.default_unless['postfix']['main']['smtpd_tls_key_file'] = '/etc/ssl/private/ssl-cert-snakeoil.key'
+  node.default_unless['postfix']['main']['smtpd_tls_CAfile'] = node['postfix']['cafile']
+  node.default_unless['postfix']['main']['smtpd_tls_session_cache_database'] = 'btree:${data_directory}/smtpd_scache'
 end
 
 if node['postfix']['main']['smtp_use_tls'] == 'yes'
-  node.default['postfix']['main']['smtp_tls_CAfile'] = node['postfix']['cafile']
-  node.default['postfix']['main']['smtp_tls_session_cache_database'] = 'btree:${data_directory}/smtp_scache'
+  node.default_unless['postfix']['main']['smtp_tls_CAfile'] = node['postfix']['cafile']
+  node.default_unless['postfix']['main']['smtp_tls_session_cache_database'] = 'btree:${data_directory}/smtp_scache'
 end
 
 if node['postfix']['main']['smtp_sasl_auth_enable'] == 'yes'
-  node.default['postfix']['sasl_password_file'] = "#{node['postfix']['conf_dir']}/sasl_passwd"
-  node.default['postfix']['main']['smtp_sasl_password_maps'] = "hash:#{node['postfix']['sasl_password_file']}"
-  node.default['postfix']['main']['smtp_sasl_security_options'] = 'noanonymous'
-  node.default['postfix']['sasl']['smtp_sasl_user_name'] = ''
-  node.default['postfix']['sasl']['smtp_sasl_passwd']    = ''
-  node.default['postfix']['main']['relayhost'] = ''
+  node.default_unless['postfix']['sasl_password_file'] = "#{node['postfix']['conf_dir']}/sasl_passwd"
+  node.default_unless['postfix']['main']['smtp_sasl_password_maps'] = "hash:#{node['postfix']['sasl_password_file']}"
+  node.default_unless['postfix']['main']['smtp_sasl_security_options'] = 'noanonymous'
+  node.default_unless['postfix']['sasl']['smtp_sasl_user_name'] = ''
+  node.default_unless['postfix']['sasl']['smtp_sasl_passwd']    = ''
+  node.default_unless['postfix']['main']['relayhost'] = ''
 end
 
 if node['postfix']['use_alias_maps']
-  node.default['postfix']['main']['alias_maps'] = ["hash:#{node['postfix']['aliases_db']}"]
+  node.default_unless['postfix']['main']['alias_maps'] = ["hash:#{node['postfix']['aliases_db']}"]
 end
 
 if node['postfix']['use_transport_maps']
-  node.default['postfix']['main']['transport_maps'] = ["hash:#{node['postfix']['transport_db']}"]
+  node.default_unless['postfix']['main']['transport_maps'] = ["hash:#{node['postfix']['transport_db']}"]
 end
 
 if node['postfix']['use_access_maps']
-  node.default['postfix']['main']['access_maps'] = ["hash:#{node['postfix']['access_db']}"]
+  node.default_unless['postfix']['main']['access_maps'] = ["hash:#{node['postfix']['access_db']}"]
 end
 
 if node['postfix']['use_virtual_aliases']
-  node.default['postfix']['main']['virtual_alias_maps'] = ["#{node['postfix']['virtual_alias_db_type']}:#{node['postfix']['virtual_alias_db']}"]
+  node.default_unless['postfix']['main']['virtual_alias_maps'] = ["#{node['postfix']['virtual_alias_db_type']}:#{node['postfix']['virtual_alias_db']}"]
 end
 
 if node['postfix']['use_virtual_aliases_domains']
-  node.default['postfix']['main']['virtual_alias_domains'] = ["#{node['postfix']['virtual_alias_domains_db_type']}:#{node['postfix']['virtual_alias_domains_db']}"]
+  node.default_unless['postfix']['main']['virtual_alias_domains'] = ["#{node['postfix']['virtual_alias_domains_db_type']}:#{node['postfix']['virtual_alias_domains_db']}"]
 end

--- a/spec/wrapper_spec.rb
+++ b/spec/wrapper_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+##
+# Spec to ensure wrapper cookbook can correctly override
+# attributes using default level without _attributes
+# recipe clearing them.
+
+describe 'wrapper::default' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new.converge(described_recipe)
+  end
+
+  describe '_attributes recipes' do
+    it 'keeps wrapper cookbook default set attributes' do
+      expect(chef_run.node['postfix']['main']['relayhost']).to eq('please')
+      expect(chef_run.node['postfix']['main']['smtp_sasl_security_options']).to eq('keep')
+      expect(chef_run.node['postfix']['sasl']['smtp_sasl_user_name']).to eq('us')
+    end
+  end
+end

--- a/test/fixtures/cookbooks/wrapper/attributes/default.rb
+++ b/test/fixtures/cookbooks/wrapper/attributes/default.rb
@@ -1,0 +1,6 @@
+
+default['postfix']['main']['smtp_sasl_auth_enable'] = 'yes'
+
+default['postfix']['main']['relayhost'] = 'please'
+default['postfix']['sasl']['smtp_sasl_user_name'] = 'keep'
+default['postfix']['sasl']['smtp_sasl_passwd'] = 'us'

--- a/test/fixtures/cookbooks/wrapper/metadata.rb
+++ b/test/fixtures/cookbooks/wrapper/metadata.rb
@@ -1,0 +1,3 @@
+name 'wrapper'
+version '0.0.1'
+description 'Wrapper cookbook, used for testing only.'

--- a/test/fixtures/cookbooks/wrapper/recipes/default.rb
+++ b/test/fixtures/cookbooks/wrapper/recipes/default.rb
@@ -1,0 +1,2 @@
+
+include 'postfix'


### PR DESCRIPTION
Wrapper cookbook usually uses default level to override attributes of the wrapped cookbook. Here, we had a problem because if the wrapper cookbook was enabling sasl and was setting a `relayhost` and a user/password combination using the default level, this was not working because `_attributes` recipe resets those attributes.

To fix this, we now use node.default_unless which will set the attribute only if it's not already set ensuring that wrapper cookbook overridden attributes using default level are correctly kept when computing derived attributes.

Fixes #98 