### PR TITLE
Fix Ubuntu 15.04 support

### DIFF
--- a/recipes/_common.rb
+++ b/recipes/_common.rb
@@ -124,5 +124,8 @@ end
 
 service 'postfix' do
   supports status: true, restart: true, reload: true
+  if node['platform'] == 'ubuntu' && node['platform_version'].to_i >= 15
+    provider Chef::Provider::Service::Debian
+  end
   action :enable
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -46,4 +46,34 @@ describe 'postfix::default' do
       expect(chef_run).to_not render_file('/etc/postfix/main.cf').with_content('recipient_delimiter')
     end
   end
+
+  context 'on Ubuntu 14.04' do
+    let(:chef_runner) do
+      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: 14.04)
+        .converge(described_recipe)
+    end
+    let(:chef_run) { chef_runner.converge(described_recipe) }
+
+    it 'uses Debian service provider' do
+      expect(chef_run).to enable_service('postfix')
+        .with_provider(nil)
+    end
+  end
+
+  context 'on Ubuntu 15.04' do
+    let(:chef_runner) { ChefSpec::ServerRunner.new }
+    let(:chef_run) { chef_runner.converge(described_recipe) }
+    let(:node) { chef_runner.node }
+    # Ubuntu 15.04 still not supported by fauxhai
+    before do
+      node.automatic['platform_family'] = 'debian'
+      node.automatic['platform'] = 'ubuntu'
+      node.automatic['platform_version'] = '15.04'
+    end
+
+    it 'uses Debian service provider' do
+      expect(chef_run).to enable_service('postfix')
+        .with_provider(Chef::Provider::Service::Debian)
+    end
+  end
 end


### PR DESCRIPTION
This fixes the following error on Ubuntu `15.04`:

```
* service[postfix] action enable
  
  ================================================================================
  Error executing action `enable` on resource 'service[postfix]'
  ================================================================================
  
  Mixlib::ShellOut::ShellCommandFailed
  ------------------------------------
  Expected process to exit with [0], but received '1'
  ---- Begin output of /bin/systemctl enable postfix ----
  STDOUT: 
  STDERR: Synchronizing state for postfix.service with sysvinit using update-rc.d...
  Executing /usr/sbin/update-rc.d postfix defaults
  Executing /usr/sbin/update-rc.d postfix enable
  Failed to execute operation: No such file or directory
  ---- End output of /bin/systemctl enable postfix ----
  Ran /bin/systemctl enable postfix returned 1
  
  Resource Declaration:
  ---------------------
  # In /tmp/kitchen/cookbooks/postfix/recipes/_common.rb
  
  125: service 'postfix' do
  126:   supports status: true, restart: true, reload: true
  127:   action :enable
  128: end
  
  Compiled Resource:
  ------------------
  # Declared in /tmp/kitchen/cookbooks/postfix/recipes/_common.rb:125:in `from_file'
  
  service("postfix") do
    action [:enable]
    supports {:status=>true, :restart=>true, :reload=>true}
    retries 0
    retry_delay 2
    default_guard_interpreter :default
    service_name "postfix"
    pattern "postfix"
    declared_type :service
    cookbook_name :postfix
    recipe_name "_common"
  end
  
       
  - restart service service[postfix]
```

Travis errors of this PR are fixed in #114.