### PR TITLE
Allow generation of dhparam.pem with the given number of bits

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -39,6 +39,9 @@ suites:
 - name: server
   run_list:
   - recipe[postfix::server]
+  attributes:
+    postfix:
+      dhparam_bits: 1024
 
 - name: sasl_auth
   run_list:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ See `attributes/default.rb` for default values.
 * `node['postfix']['virtual_aliases']` - hash of virtual_aliases to create with `recipe[postfix::virtual_aliases]`, see below under __Recipes__ for more information.
 * `node['postfix']['main_template_source']` - Cookbook source for main.cf template. Default 'postfix'
 * `node['postfix']['master_template_source']` - Cookbook source for master.cf template. Default 'postfix'
+* `node['postfix']['dhparam_bits']` - Number of bits to generate for dhparam.pem or nil (default) to use the built-in parameters
 
 ### main.cf and sasl\_passwd template attributes
 The main.cf template has been simplified to include any attributes in the `node['postfix']['main']` data structure.  The following attributes are still included with this cookbook to maintain some semblance of backwards compatibility.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,6 +39,7 @@ default['postfix']['aliases_db_type'] = 'hash'
 default['postfix']['transport_db_type'] = 'hash'
 default['postfix']['virtual_alias_db_type'] = 'hash'
 default['postfix']['virtual_alias_domains_db_type'] = 'hash'
+default['postfix']['dhparam_bits'] = nil
 
 case node['platform']
 when 'smartos'

--- a/metadata.rb
+++ b/metadata.rb
@@ -41,6 +41,11 @@ attribute 'postfix/access',
           description: "Hash of Postfix accesses mapping a pattern to a action.  Example 'domain.tld' => 'OK'.  See access man page for details.",
           type: 'hash'
 
+attribute 'postfix/dhparam_bits',
+          display_name: 'Postfix DH Parameter Bits',
+          description: 'Number of bits to generate or nil to use the built-in parameters',
+          default: nil
+
 attribute 'postfix/mail_type',
           display_name: 'Postfix Mail Type',
           description: 'Is this node a client or server?',

--- a/recipes/_common.rb
+++ b/recipes/_common.rb
@@ -110,6 +110,21 @@ unless node['postfix']['smtp_generic_map_entries'].empty?
   end
 end
 
+unless node['postfix']['dhparam_bits'].nil?
+  dhparam_path = "#{node['postfix']['conf_dir']}/dhparam.pem"
+  node.default['postfix']['main']['smtpd_tls_dh1024_param_file'] = dhparam_path
+
+  # We would use a file resource but lazy isn't lazy enough.
+  template dhparam_path do
+    source 'dhparam.pem.erb'
+    owner 'root'
+    group node['root_group']
+    mode '0600'
+    sensitive true
+    action :create_if_missing
+  end
+end
+
 %w( main master ).each do |cfg|
   template "#{node['postfix']['conf_dir']}/#{cfg}.cf" do
     source "#{cfg}.cf.erb"

--- a/templates/default/dhparam.pem.erb
+++ b/templates/default/dhparam.pem.erb
@@ -1,0 +1,5 @@
+<%=
+require 'openssl'
+Chef::Log.warn("Generating dhparam.pem, this will take a while...")
+OpenSSL::PKey::DH.new(node['postfix']['dhparam_bits'], 2)
+-%>


### PR DESCRIPTION
This is good for security as the currently widespread default of 1024-bit is now considered weak. We won't set 2048-bit by default though because this can take several minutes to generate on some hardware.