### PR TITLE
Added use of map db type overrides for access, alias and transport attributes

### DIFF
--- a/recipes/_attributes.rb
+++ b/recipes/_attributes.rb
@@ -40,15 +40,15 @@ if node['postfix']['main']['smtp_sasl_auth_enable'] == 'yes'
 end
 
 if node['postfix']['use_alias_maps']
-  node.default_unless['postfix']['main']['alias_maps'] = ["hash:#{node['postfix']['aliases_db']}"]
+  node.default_unless['postfix']['main']['alias_maps'] = ["#{node['postfix']['aliases_db_type']}:#{node['postfix']['aliases_db']}"]
 end
 
 if node['postfix']['use_transport_maps']
-  node.default_unless['postfix']['main']['transport_maps'] = ["hash:#{node['postfix']['transport_db']}"]
+  node.default_unless['postfix']['main']['transport_maps'] = ["#{node['postfix']['transport_db_type']}:#{node['postfix']['transport_db']}"]
 end
 
 if node['postfix']['use_access_maps']
-  node.default_unless['postfix']['main']['access_maps'] = ["hash:#{node['postfix']['access_db']}"]
+  node.default_unless['postfix']['main']['access_maps'] = ["#{node['postfix']['access_db_type']}:#{node['postfix']['access_db']}"]
 end
 
 if node['postfix']['use_virtual_aliases']


### PR DESCRIPTION
### Description

Adds the usage and override of existing attributes:
- default['postfix']['access_db_type'] = 'hash'
- default['postfix']['aliases_db_type'] = 'hash'
- default['postfix']['transport_db_type'] = 'hash'
### Issues Resolved

None, simply builds on existing attributes to allow non-default db types (ie: regexp)
### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
