### PR TITLE
relayhost shouldn't be configured on relay server

### DIFF
--- a/recipes/_common.rb
+++ b/recipes/_common.rb
@@ -117,7 +117,6 @@ end
     group node['root_group']
     mode '0644'
     notifies :restart, 'service[postfix]'
-    variables(settings: node['postfix'][cfg])
     cookbook node['postfix']["#{cfg}_template_source"]
   end
 end

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -24,11 +24,10 @@ if Chef::Config[:solo]
 end
 
 query = "role:#{node['postfix']['relayhost_role']}"
-relayhost = ''
-# results = []
 
 if node.run_list.roles.include?(node['postfix']['relayhost_role'])
-  relayhost << node['ipaddress']
+  Chef::Log.info("#{cookbook_name}::#{recipe_name} We shouldn't set relayhost for relay server")
+  return
 elsif node['postfix']['multi_environment_relay']
   results = search(:node, query)
   relayhost = results.map { |n| n['ipaddress'] }.first
@@ -37,6 +36,6 @@ else
   relayhost = results.map { |n| n['ipaddress'] }.first
 end
 
-node.set['postfix']['main']['relayhost'] = "[#{relayhost}]"
+node.default['postfix']['main']['relayhost'] = relayhost
 
 include_recipe 'postfix'

--- a/templates/default/main.cf.erb
+++ b/templates/default/main.cf.erb
@@ -3,7 +3,7 @@
 # Configured as <%= node['postfix']['mail_type'] %>
 ###
 
-<% @settings.sort.map do |key, value| -%>
+<% node['postfix']['main'].sort.map do |key, value| -%>
 <%  next if value.nil? -%>
 <%  if value.kind_of? Array -%>
 <%=   "#{key} = #{value.join(', ')}"%>

--- a/templates/default/master.cf.erb
+++ b/templates/default/master.cf.erb
@@ -7,7 +7,7 @@
 #               (yes)   (yes)   (yes)   (never) (100)
 # ==========================================================================
 smtp      inet  n       -       n       -       -       smtpd
-<% if @settings['submission'] -%>
+<% if node['postfix']['master']['submission'] -%>
 submission inet n       -       n       -       -       smtpd
   -o smtpd_enforce_tls=yes
   -o smtpd_sasl_auth_enable=yes


### PR DESCRIPTION
### Description

Removed using of normal attribute from recipe postfix::client
node['postfix']['main']['relayhost'] shouldn't be changed if client cookbook is runned on relay host node
### Issues Resolved

Avoid mail sending loop when client cookbook is launched on relay host.

[List any existing issues this PR resolves]
