### PR TITLE
fixing /etc/aliases syntax for full-mailaddresses

### DIFF
--- a/templates/default/aliases.erb
+++ b/templates/default/aliases.erb
@@ -6,5 +6,5 @@
 postmaster:    root
 
 <% node['postfix']['aliases'].each do |name, value| %>
-<%= name %>: <%= [value].flatten.map{|x| %Q("#{x}")}.join(', ') %>
+<%= name %>: <%= [value].flatten.map{|x| if (x.include?("@")) then x else %Q("#{x}") end}.join(', ') %>
 <% end unless node['postfix']['aliases'].nil? %>


### PR DESCRIPTION
### Description
This PR changes the /etc/aliases template, which now inserts full emailaddresses *without* quotes, therefore fixes the Issue 129 as mentioned below.

After:
```
$ cat www /etc/aliases
#
# This file is generated by Chef
#
# (...)
www: "sysadmin@company.com"
```
Before:
```
$ cat www /etc/aliases
#
# This file is generated by Chef
#
# (...)
www: sysadmin@company.com

```

### Issues Resolved
https://github.com/chef-cookbooks/postfix/issues/129
