### PR TITLE
lazy evaluation of template variables

### DIFF
--- a/recipes/_common.rb
+++ b/recipes/_common.rb
@@ -135,7 +135,9 @@ end
     group node['root_group']
     mode '0644'
     notifies :restart, 'service[postfix]'
-    variables(settings: node['postfix'][cfg])
+    variables(
+      lazy { { settings: node['postfix'][cfg] } }
+    )
     cookbook node['postfix']["#{cfg}_template_source"]
   end
 end


### PR DESCRIPTION
### Description

With this PR it is possible to override attributes like `node['postfix']['main']['myhostname']` after e.g. changing the host name during a chef run.

Example:

```
ruby_block 'overrideAttributes' do
    block do
        node.override['postfix']['main']['myhostname'] = (node['fqdn'] || node['hostname']).to_s.chomp('.')
        node.override['postfix']['main']['mydomain'] = (node['domain'] || node['hostname']).to_s.chomp('.')
        node.override['postfix']['main']['myorigin'] = '$myhostname'
        node.override['postfix']['main']['mydestination'] = [node['postfix']['main']['myhostname'], node['hostname'], 'localhost.localdomain', 'localhost'].compact
    end
end
```
