### PR TITLE
Fix support for Amazon Linux

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -99,6 +99,8 @@ when 'smartos'
   default['postfix']['cafile'] = '/opt/local/etc/postfix/cacert.pem'
 when 'rhel'
   default['postfix']['cafile'] = '/etc/pki/tls/cert.pem'
+when 'amazon'
+  default['postfix']['cafile'] = '/etc/pki/tls/cert.pem'
 else
   default['postfix']['cafile'] = "#{node['postfix']['conf_dir']}/cacert.pem"
 end

--- a/recipes/_common.rb
+++ b/recipes/_common.rb
@@ -24,7 +24,7 @@ package 'postfix'
 package 'procmail' if node['postfix']['use_procmail']
 
 case node['platform_family']
-when 'rhel', 'fedora'
+when 'rhel', 'fedora', 'amazon'
   service 'sendmail' do
     action :nothing
   end

--- a/recipes/sasl_auth.rb
+++ b/recipes/sasl_auth.rb
@@ -33,6 +33,8 @@ when 'rhel'
               else
                 %w(cyrus-sasl cyrus-sasl-plain ca-certificates)
               end
+when 'amazon'
+  sasl_pkgs = %w(cyrus-sasl cyrus-sasl-plain ca-certificates)
 when 'fedora'
   sasl_pkgs = %w(cyrus-sasl cyrus-sasl-plain ca-certificates)
 end


### PR DESCRIPTION
### Description

Fixed support for Amazon Linux in Chef 13.
`platform_family` of Amazon Linux is judged as amazon in Chef 13, so this recipe skipped some processes.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
