### PR TITLE
Add `packages` attribute so different postfix packages can be installed

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+default['postfix']['packages'] = %w[postfix]
+
 # Generic cookbook attributes
 default['postfix']['mail_type'] = 'client'
 default['postfix']['relayhost_role'] = 'relayhost'

--- a/recipes/_common.rb
+++ b/recipes/_common.rb
@@ -19,7 +19,7 @@
 
 include_recipe 'postfix::_attributes'
 
-package 'postfix'
+package node['postfix']['packages']
 
 package 'procmail' if node['postfix']['use_procmail']
 


### PR DESCRIPTION
### Description

The change allows specifying different postfix package name(s) to be installed.
For example, I want to be able to install `postfix32u` package from IUS.io repo in my wrapper cookbook.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
