### PR TITLE
add ability to set network connection port for a remote relayhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ See `attributes/default.rb` for default values.
 
 - `node['postfix']['mail_type']` - Sets the kind of mail configuration. `master` will set up a server (relayhost).
 - `node['postfix']['relayhost_role']` - name of a role used for search in the client recipe.
+- `node['postfix']['relayhost_port']` - listening network port of the relayhost.
 - `node['postfix']['multi_environment_relay']` - set to true if nodes should not constrain search for the relayhost in their own environment.
 - `node['postfix']['use_procmail']` - set to true if nodes should use procmail as the delivery agent.
 - `node['postfix']['use_alias_maps']` - set to true if you want the cookbook to use/configure alias maps

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,7 @@
 # Generic cookbook attributes
 default['postfix']['mail_type'] = 'client'
 default['postfix']['relayhost_role'] = 'relayhost'
+default['postfix']['relayhost_port'] = '25'
 default['postfix']['multi_environment_relay'] = false
 default['postfix']['use_procmail'] = false
 default['postfix']['use_alias_maps'] = (node['platform'] == 'freebsd')

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -24,6 +24,9 @@ end
 
 query = "role:#{node['postfix']['relayhost_role']}"
 relayhost = ''
+# if the relayhost_port attribute is not port 25, append to the relayhost
+relayhost_port = node['postfix']['relayhost_port'].to_s != '25' ? ":#{node['postfix']['relayhost_port']}" : ''
+
 # results = []
 
 if node.run_list.roles.include?(node['postfix']['relayhost_role'])
@@ -36,6 +39,6 @@ else
   relayhost = results.map { |n| n['ipaddress'] }.first
 end
 
-node.normal['postfix']['main']['relayhost'] = "[#{relayhost}]"
+node.normal['postfix']['main']['relayhost'] = "[#{relayhost}]#{relayhost_port}"
 
 include_recipe 'postfix'


### PR DESCRIPTION
Signed-off-by: Joshua Colson <joshua.colson@gmail.com>

### Description

This update adds the `relayhost_port` attribute which enables setting the connection port of the remote relayhost for environments where the remote host is not listening on the default port 25.

### Issues Resolved

N/A

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
-- All relevant tests pass. However, the converge on the client-opensuse-leap-42 suite failed because the 'postdrop' group is named 'maildrop'. The failure is unrelated to the change in this PR.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
