### PR TITLE
Fixed sbin issue with Chef13 \nSigned-off-by: Scott Marshall  <scott.…

### DIFF
--- a/recipes/relay_restrictions.rb
+++ b/recipes/relay_restrictions.rb
@@ -15,8 +15,10 @@
 
 include_recipe 'postfix::_common'
 
+postmap_command = platform_family?('rhel') ? '/usr/sbin/postmap' : 'postmap'
+
 execute 'update-postfix-relay-restrictions' do
-  command "postmap #{node['postfix']['relay_restrictions_db']}"
+  command "#{postmap_command} #{node['postfix']['relay_restrictions_db']}"
   environment PATH: "#{ENV['PATH']}:/opt/omni/bin:/opt/omni/sbin" if platform_family?('omnios')
   action :nothing
 end


### PR DESCRIPTION
Signed-off-by: Scott Marshall  <scott.marshall@johnmuirhealth.com>

### Description

postmap fails on rhel systems because execute does not see /usr/sbin.

### Issues Resolved



### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
