### PR TITLE
Remove unused SASL attributes from sasl_passwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ This change in namespace to `node['postfix']['main']` should allow for greater f
 - `node['postfix']['sender_canonical_map_entries']` - (hash with key value pairs); default not configured. Setup generic canonical maps. See `man 5 canonical`. If has at least one value, then will be enabled in config.
 - `node['postfix']['smtp_generic_map_entries']` - (hash with key value pairs); default not configured. Setup generic postfix maps. See `man 5 generic`. If has at least one value, then will be enabled in config.
 - `node['postfix']['recipient_canonical_map_entries']` - (hash with key value pairs); default not configured. Setup generic canonical maps. See `man 5 canonical`. If has at least one value, then will be enabled in config.
-- `node['postfix']['sasl']['smtp_sasl_user_name']` - SASL user to authenticate as. Default empty. You can only use this until the current version. The new syntax is below.
-- `node['postfix']['sasl']['smtp_sasl_passwd']` - SASL password to use. Default empty. You can only use this until the current version. The new syntax is below.
 - `node['postfix']['sasl']` = ```json {
     "relayhost1" => {
       'username' => 'foo',

--- a/recipes/_attributes.rb
+++ b/recipes/_attributes.rb
@@ -33,8 +33,6 @@ if node['postfix']['main']['smtp_sasl_auth_enable'] == 'yes'
   node.default_unless['postfix']['sasl_password_file'] = "#{node['postfix']['conf_dir']}/sasl_passwd"
   node.default_unless['postfix']['main']['smtp_sasl_password_maps'] = "hash:#{node['postfix']['sasl_password_file']}"
   node.default_unless['postfix']['main']['smtp_sasl_security_options'] = 'noanonymous'
-  node.default_unless['postfix']['sasl']['smtp_sasl_user_name'] = ''
-  node.default_unless['postfix']['sasl']['smtp_sasl_passwd']    = ''
   node.default_unless['postfix']['main']['relayhost'] = ''
 end
 

--- a/spec/wrapper_spec.rb
+++ b/spec/wrapper_spec.rb
@@ -14,8 +14,8 @@ describe 'test::default' do
     it 'keeps wrapper cookbook default set attributes' do
       expect(chef_run.node['postfix']['main']['relayhost']).to eq('please')
       expect(chef_run.node['postfix']['main']['smtp_sasl_security_options']).to eq('keep')
-      expect(chef_run.node['postfix']['sasl']['smtp_sasl_user_name']).to eq('us')
-      expect(chef_run.node['postfix']['sasl']['smtp_sasl_passwd']).to eq('happy')
+      expect(chef_run.node['postfix']['sasl']['please']['username']).to eq('us')
+      expect(chef_run.node['postfix']['sasl']['please']['password']).to eq('happy')
     end
   end
 end

--- a/test/fixtures/cookbooks/test/attributes/default.rb
+++ b/test/fixtures/cookbooks/test/attributes/default.rb
@@ -1,6 +1,5 @@
 default['postfix']['main']['smtp_sasl_auth_enable'] = 'yes'
 default['postfix']['main']['relayhost'] = 'please'
 default['postfix']['main']['smtp_sasl_security_options'] = 'keep'
-default['postfix']['sasl']['smtp_sasl_user_name'] = 'us'
-default['postfix']['sasl']['smtp_sasl_passwd'] = 'happy'
+default['postfix']['sasl'] = { 'please' => { 'username' => 'us', 'password' => 'happy' } }
 default['postfix']['sender_canonical_map_entries'] = {}


### PR DESCRIPTION
'smtp_sasl_user_name' and 'smtp_sasl_passwd' turned up in
templates/sasl_passwd.erb's @settings.sort.map and wrongly
put into the configuration file as relayhost names.

### Description

This brings file /etc/postfix/sasl_passwd back to the working format
before introducing the "multiple-relayhost-feature" in
https://github.com/chef-cookbooks/postfix/pull/134

### Issues Resolved

https://github.com/chef-cookbooks/postfix/issues/148

### Check List

Apologies, I just noticed this issue at a customers site and currently
have no way of testing it.