### PR TITLE
fixed transports not using /usr/sbin on RHEL

### DIFF
--- a/recipes/transports.rb
+++ b/recipes/transports.rb
@@ -15,8 +15,10 @@
 
 include_recipe 'postfix::_common'
 
+postmap_command = platform_family?('rhel') ? '/usr/sbin/postmap' : 'postmap'
+
 execute 'update-postfix-transport' do
-  command "postmap #{node['postfix']['transport_db']}"
+  command "#{postmap_command} #{node['postfix']['transport_db']}"
   environment PATH: "#{ENV['PATH']}:/opt/omni/bin:/opt/omni/sbin" if platform_family?('omnios')
   action :nothing
 end


### PR DESCRIPTION
Signed-off-by: David MacMillan <dmac134@gmail.com>

### Description

The same changes made to relay_restrictions.rb in https://github.com/chef-cookbooks/postfix/commit/0dd7bc851b80b486cf2a1cfeaedd9aef7c2f437d are applied to transports.rb in this PR.

### Issues Resolved

N/A

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
