### PR TITLE
fix: don't emit bogus access_maps parameter in main.cf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: ci
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.4
     permissions:
       actions: write
       checks: write
@@ -27,20 +27,24 @@ jobs:
           - almalinux-10
           - amazonlinux-2023
           - centos-stream-9
-          - debian-11
+          - centos-stream-10
           - debian-12
+          - debian-13
           - opensuse-leap-15
           - rockylinux-8
           - rockylinux-9
+          - rockylinux-10
           - ubuntu-2004
           - ubuntu-2204
           - ubuntu-2404
+          - ubuntu-2604
         suite:
           - default
           - aliases
           - client
           - server
           - canonical
+          - access
           - sasl-auth-none
           - sasl-auth-multiple
           - sasl-auth-one
@@ -50,7 +54,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
       - name: Install Cinc Workstation
-        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.2
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Dokken
         uses: actionshub/test-kitchen@3.0.0
         env:

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -11,6 +11,6 @@ name: conventional-commits
 
 jobs:
   conventional-commits:
-    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.4
     permissions:
       pull-requests: read

--- a/.github/workflows/prevent-file-change.yml
+++ b/.github/workflows/prevent-file-change.yml
@@ -11,7 +11,7 @@ name: prevent-file-change
 
 jobs:
   prevent-file-change:
-    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.4
     permissions:
       pull-requests: write
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   release:
-    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.4
     secrets:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,10 +1,12 @@
 driver:
   name: dokken
   privileged: true
-  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
 
 transport: { name: dokken }
-provisioner: { name: dokken }
+provisioner:
+  name: dokken
+  product_name: cinc
 
 platforms:
   - name: almalinux-8
@@ -37,11 +39,6 @@ platforms:
       image: dokken/centos-stream-10
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: debian-11
-    driver:
-      image: dokken/debian-11
-      pid_one_command: /bin/systemd
-
   - name: debian-12
     driver:
       image: dokken/debian-12
@@ -70,6 +67,11 @@ platforms:
   - name: oraclelinux-9
     driver:
       image: dokken/oraclelinux-9
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: oraclelinux-10
+    driver:
+      image: dokken/oraclelinux-10
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: rockylinux-8
@@ -101,3 +103,8 @@ platforms:
     driver:
       image: dokken/ubuntu-24.04
       pid_one_command: /bin/systemd
+
+  - name: ubuntu-26.04
+    driver:
+      image: dokken/ubuntu-26.04
+      pid_one_command: /usr/lib/systemd/systemd

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -1,7 +1,6 @@
 ---
 provisioner:
-  name: chef_infra
-  product_name: chef
+  name: cinc_infra
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   channel: stable
   install_strategy: once
@@ -17,16 +16,21 @@ verifier:
 platforms:
   - name: almalinux-8
   - name: almalinux-9
+  - name: almalinux-10
   - name: amazonlinux-2023
   - name: centos-stream-9
-  - name: debian-11
+  - name: centos-stream-10
   - name: debian-12
+  - name: debian-13
   - name: fedora-latest
   - name: opensuse-leap-15
   - name: oraclelinux-8
   - name: oraclelinux-9
+  - name: oraclelinux-10
   - name: rockylinux-8
   - name: rockylinux-9
+  - name: rockylinux-10
   - name: ubuntu-20.04
   - name: ubuntu-22.04
   - name: ubuntu-24.04
+  - name: ubuntu-26.04

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -55,6 +55,10 @@ suites:
     run_list:
       - recipe[test::server]
 
+  - name: access
+    run_list:
+      - recipe[test::access]
+
   - name: canonical
     run_list:
       - recipe[test::canonical]

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -127,7 +127,7 @@ module PostfixCookbook
       settings.merge(postfix_setting('main', {}).to_h)
     end
 
-    def postfix_derived_main_settings(settings, conf_dir:, db_type:, use_procmail:, use_alias_maps:, use_transport_maps:, use_access_maps:, use_virtual_aliases:, use_virtual_aliases_domains:, use_relay_restrictions_maps:)
+    def postfix_derived_main_settings(settings, conf_dir:, db_type:, use_procmail:, use_alias_maps:, use_transport_maps:, use_virtual_aliases:, use_virtual_aliases_domains:, use_relay_restrictions_maps:)
       settings = settings.dup
       cafile = postfix_cafile(conf_dir)
 
@@ -150,7 +150,6 @@ module PostfixCookbook
 
       settings['alias_maps'] ||= ["#{db_type}:#{postfix_path(:aliases_db)}"] if use_alias_maps
       settings['transport_maps'] ||= ["#{db_type}:#{postfix_path(:transport_db)}"] if use_transport_maps
-      settings['access_maps'] ||= ["#{db_type}:#{postfix_path(:access_db)}"] if use_access_maps
       settings['virtual_alias_maps'] ||= ["#{postfix_setting('virtual_alias_db_type') || db_type}:#{postfix_path(:virtual_alias_db)}"] if use_virtual_aliases
       settings['virtual_alias_domains'] ||= ["#{postfix_setting('virtual_alias_domains_db_type') || db_type}:#{postfix_path(:virtual_alias_domains_db)}"] if use_virtual_aliases_domains
       settings['smtpd_relay_restrictions'] ||= "#{db_type}:#{postfix_path(:relay_restrictions_db)}, reject" if use_relay_restrictions_maps

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -62,7 +62,6 @@ action :create do
     use_procmail: use_procmail,
     use_alias_maps: use_alias_maps,
     use_transport_maps: use_transport_maps,
-    use_access_maps: use_access_maps,
     use_virtual_aliases: use_virtual_aliases,
     use_virtual_aliases_domains: use_virtual_aliases_domains,
     use_relay_restrictions_maps: use_relay_restrictions_maps

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -20,6 +20,24 @@ action :install do
   package_names = new_resource.packages || postfix_packages
   procmail = new_resource.use_procmail.nil? ? postfix_setting('use_procmail', false) : new_resource.use_procmail
 
+  # On Debian/Ubuntu the default MTA is exim4. A running exim4 holds port 25
+  # and prevents postfix/master from binding ("bind 127.0.0.1 port 25: Address
+  # already in use"), so stop and remove it before installing postfix. The
+  # service must be stopped explicitly first: purging the package does not
+  # reliably stop the running daemon, which keeps listening on port 25.
+  if platform_family?('debian')
+    service 'exim4' do
+      action [:stop, :disable]
+      only_if { ::File.exist?('/usr/sbin/exim4') }
+    end
+
+    package 'exim4' do
+      package_name %w(exim4 exim4-daemon-light exim4-config exim4-base)
+      action :purge
+      only_if { ::File.exist?('/usr/sbin/exim4') }
+    end
+  end
+
   if node['os'] == 'linux'
     package package_names
   else

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -15,6 +15,20 @@ describe 'postfix resources' do
     end
   end
 
+  context 'postfix_install with exim4 present' do
+    let(:chef_run) do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with('/usr/sbin/exim4').and_return(true)
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '24.04', step_into: postfix_step_into).converge('test::spec_install')
+    end
+
+    it 'stops and purges exim4 so postfix can bind port 25' do
+      expect(chef_run).to stop_service('exim4')
+      expect(chef_run).to disable_service('exim4')
+      expect(chef_run).to purge_package('exim4')
+    end
+  end
+
   context 'postfix_config with aliases' do
     cached(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '24.04', step_into: postfix_step_into).converge('test::spec_config_aliases')
@@ -32,6 +46,20 @@ describe 'postfix resources' do
 
     it 'renders a map file' do
       expect(chef_run).to render_file('/etc/postfix/access').with_content(/^example.com OK$/)
+    end
+  end
+
+  context 'postfix_config with access maps' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '24.04', step_into: postfix_step_into).converge('test::spec_config_access')
+    end
+
+    it 'renders the access map file' do
+      expect(chef_run).to render_file('/etc/postfix/access').with_content(/^example.com OK$/)
+    end
+
+    it 'does not emit a bogus access_maps parameter in main.cf' do
+      expect(chef_run).to_not render_file('/etc/postfix/main.cf').with_content(/access_maps/)
     end
   end
 

--- a/test/cookbooks/test/recipes/access.rb
+++ b/test/cookbooks/test/recipes/access.rb
@@ -1,0 +1,6 @@
+include_recipe 'test::net_setup'
+
+postfix 'access' do
+  use_access_maps true
+  access 'example.com' => 'OK'
+end

--- a/test/cookbooks/test/recipes/net_setup.rb
+++ b/test/cookbooks/test/recipes/net_setup.rb
@@ -1,6 +1,2 @@
 # sysctl missing on SUSE
 package 'procps' if platform_family?('suse')
-
-sysctl 'net.ipv6.conf.lo.disable_ipv6' do
-  value 0
-end

--- a/test/cookbooks/test/recipes/spec_config_access.rb
+++ b/test/cookbooks/test/recipes/spec_config_access.rb
@@ -1,0 +1,4 @@
+postfix_config 'default' do
+  use_access_maps true
+  access 'example.com' => 'OK'
+end

--- a/test/integration/access/controls/access.rb
+++ b/test/integration/access/controls/access.rb
@@ -1,0 +1,20 @@
+include_controls 'default'
+
+control 'access' do
+  describe file '/etc/postfix/access' do
+    it { should exist }
+    its('content') { should match(/^example.com OK$/) }
+  end
+
+  # access(5) maps are consulted via check_*_access lookups, not as a
+  # standalone main.cf parameter. Ensure we never write a bogus
+  # access_maps setting (regression test for the 7.0.0 rewrite).
+  describe file '/etc/postfix/main.cf' do
+    its('content') { should_not match(/access_maps/) }
+  end
+
+  # postconf warns about unused parameters; a clean check must be silent.
+  describe command('postconf -n 2>&1 >/dev/null') do
+    its('stdout') { should_not match(/access_maps/) }
+  end
+end

--- a/test/integration/access/inspec.yml
+++ b/test/integration/access/inspec.yml
@@ -1,0 +1,4 @@
+name: access
+depends:
+  - name: default
+    path: test/integration/default


### PR DESCRIPTION
access(5) maps are read via check_*_access lookups in the
smtpd_*_restrictions, not as a main.cf parameter. The 7.0.0 rewrite wrote
a bogus access_maps setting, making postconf log "unused parameter:
access_maps=..." on every check. This drops it (the access map file is
still rendered) and also:

- stop, disable and purge exim4 before installing postfix on Debian so
  postfix/master can bind port 25
- add the access integration suite and refresh the CI OS matrix (add
  centos-stream-10, debian-13, rockylinux-10, ubuntu-2604; drop debian-11)
- bump shared sous-chefs/.github actions to 8.0.4

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves.

## Issues Resolved

List any existing issues this PR resolves.

## Check List

- [ ] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
  - **Required**: This triggers our automated CHANGELOG and release pipeline (release-please)
  - **Without conventional commits, your changes cannot be released**
  - Examples: `fix: resolve bug in resource`, `feat: add new property`, `docs: update README`
- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable

## ⚠️ Important: Automated Release Workflow

**DO NOT manually edit these files:**

- ❌ `metadata.rb` version - Managed by release-please
- ❌ `CHANGELOG.md` - Auto-generated from conventional commits
- ❌ Version tags - Created automatically on release

**The release process:**

1. Merge PR with conventional commits → release-please creates a release PR
2. Merge release PR → automatic version bump, CHANGELOG update, and Supermarket publish
3. Your changes are released! 🎉

**Need help?** See [Conventional Commits guide](https://www.conventionalcommits.org/)
