### PR TITLE
fix: migrate to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Postfix Cookbook Limitations
+# Postfix Cookbook Notes
 
 This cookbook manages Postfix through operating system packages and service/configuration files. It does not build Postfix from source.
 
@@ -9,6 +9,8 @@ Supported cookbook platforms are limited to current package-based Linux distribu
 FreeBSD, SmartOS, Scientific Linux, and legacy CentOS releases were removed from cookbook support during the resource migration because the current cookbook test matrix and service implementation are Linux/package oriented.
 
 Map backends depend on distribution packages and Postfix module availability. The `postfix_map` resource only runs `postmap` for database-backed map types such as `hash`, `lmdb`, `btree`, `cdb`, `dbm`, and `sdbm`.
+
+Dependency resolution uses `Policyfile.rb`. Keep test cookbook suites represented as Policyfile named run lists so Kitchen can select them with `provisioner.named_run_list`.
 
 Sources:
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,8 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'apt'
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -5,7 +5,6 @@ name 'postfix'
 run_list 'test::default'
 
 cookbook 'postfix', path: '.'
-cookbook 'apt', git: 'https://github.com/sous-chefs/apt.git', branch: 'main'
 cookbook 'test', path: './test/cookbooks/test'
 
 Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+name 'postfix'
+
+run_list 'test::default'
+
+cookbook 'postfix', path: '.'
+cookbook 'apt', git: 'https://github.com/sous-chefs/apt.git', branch: 'main'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, "test::#{recipe_name}"
+end

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Installs and configures postfix for client or outbound relayhost, or to do SASL 
 
 This cookbook is resource-first. Recipes and cookbook attributes have been removed.
 
-See [migration.md](migration.md) for recipe migration guidance, [LIMITATIONS.md](LIMITATIONS.md) for supported platform constraints, and the files in [documentation/](documentation/) for resource usage.
+See [migration.md](migration.md) for recipe migration guidance, [AGENTS.md](AGENTS.md) for supported platform constraints, and the files in [documentation/](documentation/) for resource usage.
 
 On RHEL-family systems, sendmail will be replaced with postfix.
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,12 +1,14 @@
 driver:
   name: dokken
   privileged: true
-  chef_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
+  chef_image: "<%= ENV.fetch('KITCHEN_PRODUCT_NAME', 'cinc') == 'cinc' ? 'cincproject/cinc' : 'chef/chef' %>"
+  chef_version: "<%= ENV['CHEF_VERSION'] || (ENV.fetch('KITCHEN_PRODUCT_NAME', 'cinc') == 'cinc' ? 'latest' : 'current') %>"
 
 transport: { name: dokken }
 provisioner:
   name: dokken
-  product_name: cinc
+  chef_binary: "<%= ENV.fetch('KITCHEN_PRODUCT_NAME', 'cinc') == 'cinc' ? '/opt/cinc/bin/cinc-client' : '/opt/chef/bin/chef-client' %>"
+  product_name: "<%= ENV['KITCHEN_PRODUCT_NAME'] || 'cinc' %>"
 
 platforms:
   - name: almalinux-8

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -1,6 +1,7 @@
 ---
 provisioner:
-  name: cinc_infra
+  name: policyfile_zero
+  product_name: <%= ENV['KITCHEN_PRODUCT_NAME'] || 'cinc' %>
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   channel: stable
   install_strategy: once
@@ -9,6 +10,7 @@ provisioner:
   multiple_converge: <%= ENV['MULTIPLE_CONVERGE'] || 2 %>
   deprecations_as_errors: true
   log_level: <%= ENV['CHEF_LOG_LEVEL'] || 'auto' %>
+  policyfile: Policyfile.rb
 
 verifier:
   name: inspec

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,11 +3,12 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_infra
-  product_name: chef
+  name: policyfile_zero
+  product_name: cinc
   enforce_idempotency: true
   multiple_converge: 2
   deprecations_as_errors: true
+  policyfile: Policyfile.rb
 
 verifier:
   name: inspec
@@ -29,12 +30,12 @@ platforms:
 
 suites:
   - name: default
-    run_list:
-      - recipe[test::default]
+    provisioner:
+      named_run_list: default
 
   - name: aliases
-    run_list:
-      - recipe[test::aliases]
+    provisioner:
+      named_run_list: aliases
     attributes:
       postfix:
         aliases:
@@ -48,28 +49,28 @@ suites:
             - bar
 
   - name: client
-    run_list:
-      - recipe[test::client]
+    provisioner:
+      named_run_list: client
 
   - name: server
-    run_list:
-      - recipe[test::server]
+    provisioner:
+      named_run_list: server
 
   - name: access
-    run_list:
-      - recipe[test::access]
+    provisioner:
+      named_run_list: access
 
   - name: canonical
-    run_list:
-      - recipe[test::canonical]
+    provisioner:
+      named_run_list: canonical
     attributes:
       postfix:
         recipient_canonical_map_entries:
           john: john@doe.com
 
   - name: sasl_auth_none
-    run_list:
-      - recipe[test::sasl_auth_none]
+    provisioner:
+      named_run_list: sasl_auth_none
     attributes:
       postfix:
         main:
@@ -77,8 +78,8 @@ suites:
           smtp_sasl_auth_enable: "yes"
 
   - name: sasl_auth_multiple
-    run_list:
-      - recipe[test::sasl_auth_multiple]
+    provisioner:
+      named_run_list: sasl_auth_multiple
     attributes:
       postfix:
         main:
@@ -93,8 +94,8 @@ suites:
             password: "yet-not-a-real-thing"
 
   - name: sasl_auth_one
-    run_list:
-      - recipe[test::sasl_auth_one]
+    provisioner:
+      named_run_list: sasl_auth_one
     attributes:
       postfix:
         main:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary

* migrate cookbook dependency resolution from Berksfile to Policyfile.rb
* switch ChefSpec to chefspec/policyfile and preserve Kitchen suite run lists with named_run_list
* replace LIMITATIONS.md with AGENTS.md and update Copilot setup to run chef install Policyfile.rb
* set the Dokken Cinc chef_binary so the Policyfile integration lane converges with the Cinc container

## Validation

* `chef install Policyfile.rb`
* `git diff --check`
* `cookstyle`
* `env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec --format documentation`
* `env KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list`
* `env KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen test default-ubuntu-2404 --destroy=always`
* `actionlint`
* `yamllint .`
* `markdownlint-cli2 "**/*.md"`
